### PR TITLE
Improve narrow viewport layout spacing

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -805,7 +805,7 @@
 @media (max-width: 1200px) {
   .app-shell {
     flex-direction: column;
-    padding: 0 16px 16px;
+    padding: 0 0 16px;
   }
 
   .sidebar--compact {
@@ -865,6 +865,18 @@
 }
 
 @media (max-width: 768px) {
+  .app-shell {
+    padding: 0 0 12px;
+  }
+
+  .dashboard__grid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+
+  .dashboard__grid--two {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+
   .topbar--hero {
     top: 0;
     padding: 24px;


### PR DESCRIPTION
## Summary
- reduce horizontal padding on the app shell in tablet layouts so content can span the viewport
- lower the dashboard grid min-widths on small screens to avoid horizontal overflow

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e2bad142108323a0f989d9094be312