### PR TITLE
Ensure sidebar labels remain visible on touch layouts

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -836,6 +836,20 @@
     justify-content: flex-end;
   }
 
+  .sidebar__icon-button {
+    width: auto;
+    justify-content: flex-start;
+    gap: 12px;
+    padding-inline: 16px;
+  }
+
+  .sidebar__label {
+    opacity: 1;
+    transform: none;
+    max-width: none;
+    pointer-events: auto;
+  }
+
   .topbar__actions {
     flex-wrap: wrap;
     justify-content: flex-start;


### PR DESCRIPTION
## Summary
- keep compact sidebar labels visible within the horizontal mobile layout breakpoint
- adjust icon button spacing in that layout so label text fits without breaking the row

## Testing
- Manual touch simulation via Playwright (iPhone 12 preset)

------
https://chatgpt.com/codex/tasks/task_e_68e2bc26c96c8323a205803c1f5f1f29