### PR TITLE
Adjust sidebar layout for small screens

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -816,15 +816,19 @@
     justify-content: center;
     gap: 20px;
     margin-top: 0;
-    top: 16px;
     flex-wrap: wrap;
-    align-items: center;
+    align-items: stretch;
+    position: static;
+    top: auto;
+    height: auto;
+    overflow: visible;
+    overflow-y: visible;
   }
 
   .sidebar__nav,
   .sidebar__bottom {
     flex-direction: row;
-    align-items: center;
+    align-items: stretch;
     gap: 12px;
   }
 


### PR DESCRIPTION
## Summary
- reset the compact sidebar to use static positioning and natural height within the 1200px breakpoint
- stretch sidebar sections inside the responsive breakpoint so they align to the top of the container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2c3106f208323887060781645c7b8