### PR TITLE
feat: add responsive mobile top bar layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -415,6 +415,80 @@
   gap: 20px;
 }
 
+.topbar__row--mobile {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 18px;
+}
+
+.topbar__mobile-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: 100%;
+}
+
+.topbar__mobile-title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--color-text-strong);
+}
+
+.topbar__mobile-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  justify-content: flex-end;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.topbar__mobile-tools {
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.topbar__quick-actions--mobile {
+  width: 100%;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 18px;
+}
+
+.topbar__round--compact {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+}
+
+.topbar__avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  border: none;
+  background: var(--topbar-button-gradient);
+  color: var(--topbar-text-color);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  box-shadow: var(--topbar-button-shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.topbar__avatar:hover {
+  transform: translateY(-2px) scale(1.04);
+  box-shadow: var(--topbar-button-hover-shadow);
+}
+
+.topbar__avatar:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(148, 163, 255, 0.3), var(--topbar-button-shadow);
+}
+
 .topbar__quick-actions {
   display: flex;
   align-items: center;
@@ -500,6 +574,41 @@
   margin-inline-start: auto;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06), 0 18px 28px -20px rgba(15, 23, 42, 0.55);
   transition: width 0.32s ease, background 0.32s ease, border 0.32s ease, box-shadow 0.32s ease, gap 0.24s ease;
+}
+
+.topbar__search--mobile {
+  width: 44px;
+  min-width: 44px;
+  height: 44px;
+  padding: 0 6px;
+  margin-inline-start: 0;
+  background: rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(148, 163, 255, 0.28);
+  box-shadow: none;
+  justify-content: flex-start;
+  gap: 0;
+  transition: width 0.3s ease, background 0.3s ease, border 0.3s ease, box-shadow 0.3s ease;
+}
+
+.topbar__search--mobile.is-open {
+  width: 100%;
+  background: rgba(15, 23, 42, 0.92);
+  border-color: rgba(148, 163, 255, 0.45);
+  box-shadow: 0 22px 42px -32px rgba(15, 23, 42, 0.45);
+  gap: 10px;
+}
+
+.topbar__search--mobile .topbar__search-toggle {
+  width: 36px;
+  margin-right: 0;
+}
+
+.topbar__search--mobile .topbar__shortcut {
+  display: none;
+}
+
+.topbar__search--mobile.is-open .topbar__search-input {
+  margin-inline-start: 6px;
 }
 
 .topbar__search.is-open {
@@ -1107,49 +1216,66 @@
 
   .topbar--hero {
     top: 0;
-    padding: 24px;
-    gap: 20px;
+    padding: 20px 18px;
+    gap: 18px;
   }
 
   .topbar--hero.is-compact,
   .topbar--hero.is-solid {
-  color: var(--color-text-strong);
-  background: var(--topbar-gradient);
-  box-shadow: var(--topbar-shadow);
-  border-bottom-color: var(--color-border);
-  backdrop-filter: blur(24px);
-  border-radius: 28px;
-  top: 14px;
-}
+    color: var(--color-text-strong);
+    background: var(--topbar-gradient);
+    box-shadow: var(--topbar-shadow);
+    border-bottom-color: var(--color-border);
+    backdrop-filter: blur(24px);
+    border-radius: 24px;
+    top: 12px;
+  }
 
-  .topbar__row {
-    flex-direction: column;
-    align-items: flex-start;
+  .topbar__row--mobile {
     gap: 16px;
   }
 
-  .topbar__actions {
+  .topbar__mobile-title {
+    font-size: 18px;
+  }
+
+  .topbar__mobile-actions {
+    gap: 8px;
+  }
+
+  .topbar__mobile-actions .topbar__search--mobile {
+    flex: 0 0 auto;
+  }
+
+  .topbar__mobile-actions .topbar__search--mobile.is-open {
+    flex: 1 1 100%;
+  }
+
+  .topbar__mobile-actions .topbar__round--compact,
+  .topbar__mobile-actions .topbar__avatar {
+    flex-shrink: 0;
+  }
+
+  .topbar__mobile-tools {
+    display: flex;
+  }
+
+  .topbar__quick-actions--mobile {
+    flex-wrap: nowrap;
+    padding: 10px 12px;
+    gap: 8px;
+  }
+
+  .topbar__search--mobile {
+    width: 42px;
+    min-width: 42px;
+  }
+
+  .topbar__search--mobile.is-open {
     width: 100%;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    gap: 12px;
   }
 
-  .topbar__quick-actions {
-    flex: 1 0 100%;
-    justify-content: flex-start;
-    flex-wrap: wrap;
-    gap: 10px;
-  }
-
-  .topbar__search {
-    order: -1;
-    width: 60px;
-    justify-content: center;
-    margin-inline-start: 0;
-  }
-
-  .topbar__search.is-open {
+  .topbar__search--mobile.is-open .topbar__search-input {
     width: 100%;
   }
 

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -19,6 +19,7 @@ const TopBar = () => {
   const [isCompact, setIsCompact] = useState(false)
   const [isSolid, setIsSolid] = useState(false)
   const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const [isMobile, setIsMobile] = useState(false)
 
   const searchInputRef = useRef(null)
   const searchToggleRef = useRef(null)
@@ -39,6 +40,23 @@ const TopBar = () => {
 
     return () => {
       window.removeEventListener('scroll', handleScroll)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const mediaQuery = window.matchMedia('(max-width: 768px)')
+
+    const updateMatches = () => {
+      setIsMobile(mediaQuery.matches)
+    }
+
+    updateMatches()
+    mediaQuery.addEventListener('change', updateMatches)
+
+    return () => {
+      mediaQuery.removeEventListener('change', updateMatches)
     }
   }, [])
 
@@ -100,70 +118,122 @@ const TopBar = () => {
 
   const progressScale = useMemo(() => Math.min(Math.max(scrollProgress, 0), 1), [scrollProgress])
 
+  const searchClassName = useMemo(() => {
+    return [
+      'topbar__search',
+      isSearchOpen ? 'is-open' : '',
+      isMobile ? 'topbar__search--mobile' : '',
+    ]
+      .filter(Boolean)
+      .join(' ')
+  }, [isMobile, isSearchOpen])
+
+  const searchNode = (
+    <div className={searchClassName}>
+      <button
+        type="button"
+        ref={searchToggleRef}
+        className="topbar__search-toggle"
+        aria-label={isSearchOpen ? 'إغلاق البحث' : 'فتح البحث'}
+        onClick={toggleSearch}
+      >
+        {isSearchOpen ? <FiX size={18} /> : <FiSearch size={18} />}
+      </button>
+      <input
+        ref={searchInputRef}
+        type="search"
+        className="topbar__search-input"
+        placeholder="بحث سريع..."
+        aria-hidden={!isSearchOpen}
+      />
+      <kbd className="topbar__shortcut" aria-hidden={!isSearchOpen}>
+        ⌘K
+      </kbd>
+    </div>
+  )
+
   return (
     <header className={headerClassName} style={{ '--scroll-progress': scrollProgress }}>
       <div className="topbar__progress" aria-hidden="true">
         <span style={{ transform: `scaleX(${progressScale})` }} />
       </div>
-      <div className="topbar__row">
-        <div className="topbar__breadcrumbs">
-          <span>التطبيق</span>
-          <span className="topbar__chevron">›</span>
-          <span>لوحات التحكم</span>
-          <span className="topbar__chevron">›</span>
-          <strong>تحليلات</strong>
-        </div>
-        <div className="topbar__actions">
-          <div className="topbar__quick-actions" role="group">
-            <button type="button" className="topbar__round" aria-label="عرض الشبكة">
-              <FiGrid size={18} />
-            </button>
-            <button type="button" className="topbar__round" aria-label="الرسائل">
-              <FiMessageCircle size={18} />
-            </button>
-            <button type="button" className="topbar__round" aria-label="الإشعارات">
-              <FiBell size={18} />
-              <span className="topbar__badge">3</span>
-            </button>
-            <button type="button" className="topbar__round" aria-label="التقويم">
-              <FiCalendar size={18} />
-            </button>
-            <button
-              type="button"
-              className="topbar__round"
-              aria-label={isDark ? 'الوضع الفاتح' : 'الوضع الليلي'}
-              onClick={toggleTheme}
-            >
-              {isDark ? <FiSun size={18} /> : <FiMoon size={18} />}
-            </button>
-            <button type="button" className="topbar__profile">
-              <FiUser size={18} />
-              <span>سالي</span>
-              <FiChevronDown size={16} />
-            </button>
-          </div>
-          <div className={`topbar__search${isSearchOpen ? ' is-open' : ''}`}>
-            <button
-              type="button"
-              ref={searchToggleRef}
-              className="topbar__search-toggle"
-              aria-label={isSearchOpen ? 'إغلاق البحث' : 'فتح البحث'}
-              onClick={toggleSearch}
-            >
-              {isSearchOpen ? <FiX size={18} /> : <FiSearch size={18} />}
-            </button>
-            <input
-              ref={searchInputRef}
-              type="search"
-              className="topbar__search-input"
-              placeholder="بحث سريع..."
-              aria-hidden={!isSearchOpen}
-            />
-            <kbd className="topbar__shortcut" aria-hidden={!isSearchOpen}>
-              ⌘K
-            </kbd>
-          </div>
-        </div>
+      <div className={`topbar__row${isMobile ? ' topbar__row--mobile' : ''}`}>
+        {isMobile ? (
+          <>
+            <div className="topbar__mobile-bar">
+              <h1 className="topbar__mobile-title">General Report</h1>
+              <div className="topbar__mobile-actions">
+                {searchNode}
+                <button
+                  type="button"
+                  className="topbar__round topbar__round--compact"
+                  aria-label={isDark ? 'الوضع الفاتح' : 'الوضع الليلي'}
+                  onClick={toggleTheme}
+                >
+                  {isDark ? <FiSun size={18} /> : <FiMoon size={18} />}
+                </button>
+                <button type="button" className="topbar__avatar" aria-label="الملف الشخصي">
+                  <FiUser size={18} />
+                </button>
+              </div>
+            </div>
+            <div className="topbar__mobile-tools">
+              <div className="topbar__quick-actions topbar__quick-actions--mobile" role="group">
+                <button type="button" className="topbar__round topbar__round--compact" aria-label="عرض الشبكة">
+                  <FiGrid size={18} />
+                </button>
+                <button type="button" className="topbar__round topbar__round--compact" aria-label="الرسائل">
+                  <FiMessageCircle size={18} />
+                </button>
+                <button type="button" className="topbar__round topbar__round--compact" aria-label="الإشعارات">
+                  <FiBell size={18} />
+                  <span className="topbar__badge">3</span>
+                </button>
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="topbar__breadcrumbs">
+              <span>التطبيق</span>
+              <span className="topbar__chevron">›</span>
+              <span>لوحات التحكم</span>
+              <span className="topbar__chevron">›</span>
+              <strong>تحليلات</strong>
+            </div>
+            <div className="topbar__actions">
+              <div className="topbar__quick-actions" role="group">
+                <button type="button" className="topbar__round" aria-label="عرض الشبكة">
+                  <FiGrid size={18} />
+                </button>
+                <button type="button" className="topbar__round" aria-label="الرسائل">
+                  <FiMessageCircle size={18} />
+                </button>
+                <button type="button" className="topbar__round" aria-label="الإشعارات">
+                  <FiBell size={18} />
+                  <span className="topbar__badge">3</span>
+                </button>
+                <button type="button" className="topbar__round" aria-label="التقويم">
+                  <FiCalendar size={18} />
+                </button>
+                <button
+                  type="button"
+                  className="topbar__round"
+                  aria-label={isDark ? 'الوضع الفاتح' : 'الوضع الليلي'}
+                  onClick={toggleTheme}
+                >
+                  {isDark ? <FiSun size={18} /> : <FiMoon size={18} />}
+                </button>
+                <button type="button" className="topbar__profile">
+                  <FiUser size={18} />
+                  <span>سالي</span>
+                  <FiChevronDown size={16} />
+                </button>
+              </div>
+              {searchNode}
+            </div>
+          </>
+        )}
       </div>
     </header>
   )


### PR DESCRIPTION
## Summary
- add a matchMedia-driven mobile state that renders a compact top bar layout with condensed quick actions
- refactor the search affordance so it behaves as an icon-first control on mobile while keeping desktop behaviour intact
- extend the responsive CSS to support the mobile hero header structure and compact action buttons

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2c7363be083238bd9b571e2017445